### PR TITLE
Changed case of 'cgi' in twilio.rb require

### DIFF
--- a/lib/twilio.rb
+++ b/lib/twilio.rb
@@ -1,4 +1,4 @@
-%w<rubygems active_support CGI yajl yajl/json_gem httparty builder>.each  { |lib| require lib }
+%w<rubygems active_support cgi yajl yajl/json_gem httparty builder>.each  { |lib| require lib }
 require File.join(File.dirname(__FILE__), 'twilio', 'resource.rb')
 
 module Twilio
@@ -6,7 +6,7 @@ module Twilio
   APIError            = Class.new StandardError
   ConfigurationError  = Class.new StandardError
   InvalidStateError   = Class.new StandardError
-  
+
   class << self
     def const_missing(const_name)
       raise Twilio::ConfigurationError.new "Cannot complete request. Please set #{const_name.to_s.downcase} with Twilio::Config.setup first!"
@@ -15,3 +15,4 @@ module Twilio
 end
 
 Dir[File.join(File.dirname(__FILE__), 'twilio', '*.rb')].each { |lib| require lib }
+


### PR DESCRIPTION
CGI was in uppercase in the first line of twilio.rb, which causes the library to fail to load - it should be in lowercase, and it now is.

Great little library, though - thanks!
