### PR TITLE
Partial support when using TwiML builder

### DIFF
--- a/lib/railtie.rb
+++ b/lib/railtie.rb
@@ -8,7 +8,8 @@ module Twilio
               include ::ActionView::Template::Handlers::Compilable
 
               def compile(template)
-                %<Twilio::TwiML.build { |res| #{template.source} }>
+                partial = File.basename(template.identifier).starts_with?('_')
+                %<Twilio::TwiML.build(#{partial}) { |res| #{template.source} }>
               end
             end
           end

--- a/lib/twilio/twiml.rb
+++ b/lib/twilio/twiml.rb
@@ -1,6 +1,6 @@
 module Twilio
   module TwiML
-    def build &blk
+    def build(is_partial=false, &blk)
       xm = Builder::XmlMarkup.new(:indent => 2)
       xm.instance_eval do
         def method_missing(meth, *args, &blk)
@@ -12,8 +12,12 @@ module Twilio
           super(meth.to_s.capitalize, *args, &blk)
         end
       end
-      xm.instruct!
-      xm.response &blk
+      if is_partial
+        blk.call(xm)
+      else
+        xm.instruct!
+        xm.response &blk
+      end
     end
     extend self
   end

--- a/spec/twiml_spec.rb
+++ b/spec/twiml_spec.rb
@@ -29,5 +29,11 @@ describe Twilio::TwiML do
       "<Gather action=\"/process_gather.php\" method=\"GET\">\n    <Say>Now hit some buttons!</Say>\n  " + 
       "</Gather>\n</Response>\n"
     end
+    it 'does not include doctype or Response if is_partial is true' do
+      xml = Twilio::TwiML.build(true) do |res|
+        res.say 'This code is re-used in a partial!'
+      end
+      xml.should == "<Say>This code is re-used in a partial!</Say>\n"
+    end
   end
 end


### PR DESCRIPTION
Hi Steve-

I've added a little bit of code to this (excellent, btw) twilio gem to support using partials in your .voice templates. Example of usage:

Assuming a partial named `_room_code_prompt.voice`, the following code will insert the partial without the xml declaration or the <Response> wrapper:

```
res.say "I'm sorry, that code is invalid."
res << render(:partial => 'room_code_prompt')
```

I'd love to not have to do the `res <<` bit, but couldn't figure out a clean way to do it.

Thanks for sharing this code!

AJS
