### PR TITLE
Require active_support/inflector directly

### DIFF
--- a/lib/twilio.rb
+++ b/lib/twilio.rb
@@ -1,4 +1,4 @@
-%w<rubygems active_support cgi yajl yajl/json_gem httparty builder>.each  { |lib| require lib }
+%w<rubygems active_support active_support/inflector cgi yajl yajl/json_gem httparty builder>.each  { |lib| require lib }
 %w<resource finder persistable deletable>.each { |lib| require File.join(File.dirname(__FILE__), 'twilio', "#{lib}.rb") }
 
 module Twilio


### PR DESCRIPTION
With activesupport >= 3.0.4, the pluralization inflections aren't getting loaded properly. This causes most of the specs to fail if they hit Twilio::Finder#handle_response.
This can be fixed by requiring 'active_support/inflector', which I added to twilio.rb
