### PR TITLE
Escape colon's in query vars and default format for railtie

### DIFF
--- a/lib/railtie.rb
+++ b/lib/railtie.rb
@@ -9,7 +9,10 @@ module Twilio
               include ::ActionView::Template::Handlers::Compilable
 
               def compile(template)
-                %<Twilio::TwiML.build { |res| #{template.source} }>
+                <<-EOS
+                controller.content_type = 'text/xml'
+                Twilio::TwiML.build {|res| #{template.source} }
+                EOS
               end
             end
           end

--- a/lib/railtie.rb
+++ b/lib/railtie.rb
@@ -5,6 +5,7 @@ module Twilio
         class Template
           module Handlers
             class TwiML < ::ActionView::Template::Handler
+              self.default_format = 'text/xml'
               include ::ActionView::Template::Handlers::Compilable
 
               def compile(template)

--- a/lib/twilio/finder.rb
+++ b/lib/twilio/finder.rb
@@ -5,21 +5,21 @@ module Twilio
       hash = res.parsed_response
       if (200..299).include? res.code
         hash['api_version'] = hash['api_version'].to_s # api_version parsed as a date by http_party
-        new hash 
+        new hash
       end
     end
 
     def count(opts={})
       opts   = prepare_dates opts
-      params = "?#{URI.encode(opts.join '&')}" unless opts.empty?
+      params = prepare_params opts
 
       get("/Accounts/#{Twilio::ACCOUNT_SID}/#{resource_fragment}.json#{params}").parsed_response['total']
     end
 
     def all(opts={})
       opts   = prepare_dates opts
-      params = "?#{URI.encode(opts.join '&')}" unless opts.empty?
-      
+      params = prepare_params opts
+
       handle_response get "/Accounts/#{Twilio::ACCOUNT_SID}/#{resource_fragment}.json#{params}"
     end
 
@@ -42,6 +42,12 @@ module Twilio
           "#{k.to_s.camelize}=#{v}"
         end
       end
+    end
+
+    def prepare_params(opts)
+      # call URI twice, once to handle colon - otherwise a colon in the query var forces request to xml
+      # see: http://getsatisfaction.com/twilio/topics/json_request_returning_xml_if_query_vars_contains_a_colon
+      "?#{URI.encode(URI.encode(opts.join('&')), ":")}" unless opts.empty?
     end
 
     def handle_response(res) # :nodoc:

--- a/twilio-rb.gemspec
+++ b/twilio-rb.gemspec
@@ -10,8 +10,9 @@ Gem::Specification.new do |s|
   s.author                    = 'Stevie Graham'
   s.email                     = 'sjtgraham@mac.com'
   s.homepage                  = 'http://github.com/stevegraham/twilio-rb'
-  
+
   s.add_dependency              'activesupport', '>= 3.0.0'
+  s.add_dependency              'i18n',          '~> 0.5.0'
   s.add_dependency              'yajl-ruby',     '>= 0.7.7'
   s.add_dependency              'httparty',      '>= 0.6.1'
   s.add_dependency              'builder',       '>= 2.1.2'

--- a/twilio-rb.gemspec
+++ b/twilio-rb.gemspec
@@ -23,6 +23,4 @@ Gem::Specification.new do |s|
 
   s.files                     = Dir['README.md', 'lib/**/*']
   s.require_path              = 'lib'
-
-  s.has_rdoc                  = false
 end


### PR DESCRIPTION
This takes care of two issues. The first being that if you have a colon in your query var it breaks twilio's url parser and the request gets back xml instead of json. I'm not crazy about having to call URI.escape twice, but I couldn't think of a cleaner way.

The second issue is that rails was not loading right template handler for .voice extensions. Adding the default format to the template handler fixes this.

I also added i18n as a dependency as it's an undeclared dependency for activesupport. I noticed this when trying to run the specs in a clean rvm gemset.

I'd be happy to break apart the commits if you don't want them all.
