### PR TITLE
Suppress warning about undef'ing #object_id by not actually undef'ing it

### DIFF
--- a/lib/twilio/association_proxy.rb
+++ b/lib/twilio/association_proxy.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/string'
 
 module Twilio
   class AssociationProxy
-    instance_methods.each { |meth| undef_method meth unless meth.to_s =~ /^__/ }
+    instance_methods.each { |meth| undef_method meth unless meth.to_s =~ /^__/ || meth.to_s == 'object_id' }
     def initialize(delegator, target)
       @delegator, @target = delegator, target
       @delegator_name = @delegator.class.name.demodulize.downcase


### PR DESCRIPTION
Should be self-explanatory-- specs still pass so I don't think this should be a problem.
