### PR TITLE
Don't undef #object_id in AssocationProxy (fixes warning)

### DIFF
--- a/lib/twilio/association_proxy.rb
+++ b/lib/twilio/association_proxy.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/string'
 
 module Twilio
   class AssociationProxy
-    instance_methods.each { |meth| undef_method meth unless meth.to_s =~ /^__/ }
+    instance_methods.each { |meth| undef_method meth unless meth.to_s =~ /^__/ || meth.to_s == 'object_id' }
     def initialize(delegator, target)
       @delegator, @target = delegator, target
       @delegator_name = @delegator.class.name.demodulize.downcase


### PR DESCRIPTION
Eliminates warnings emitted when using this gem with ruby 1.9.2 and rails 3.1.0.
