### PR TITLE
Rails 3.1 TemplateHandler compatibility.

### DIFF
--- a/lib/railtie.rb
+++ b/lib/railtie.rb
@@ -4,15 +4,19 @@ module Twilio
       module ActionView
         class Template
           module Handlers
-            class TwiML < ::ActionView::Template::Handler
+            class TwiML
+              class_attribute :default_format
               self.default_format = 'text/xml'
-              include ::ActionView::Template::Handlers::Compilable
 
               def compile(template)
                 <<-EOS
                 controller.content_type = 'text/xml'
                 Twilio::TwiML.build { |res| #{template.source} }
                 EOS
+              end
+
+              def self.call(template)
+                new.compile(template)
               end
             end
           end


### PR DESCRIPTION
```
* Swiped from https://github.com/asanghi/excel_rails/commit/8a32d8573fbfa39d83a7e234c65adf6bcbcea86e
```

I thought I was going to have to fork the code for rails 3.0.x vs. 3.1.0 (as HAML does here: https://github.com/nex3/haml/issues/303 ) but the test suite passes without that ugly if statement even when I drop the activesupport dependency.  You may want to test this with a rails 3.0.x app just to make sure-- if it fails you can just do the same thing that the haml patch does.
