### PR TITLE
Eliminate "require 'twilio'" warning from rake file.

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'lib', 'twilio')
+require File.join(File.dirname(__FILE__), 'lib', 'twilio-rb')
 require 'rake/gempackagetask'
 require 'rspec'
 require 'rspec/core/rake_task'


### PR DESCRIPTION
rakefile currently issues "require 'twilio'" which is deprecated.  This now requires twilio-rb which stops the deprecation warning from being emitted.
