### PR TITLE
Silence yajl-ruby deprecation warning.

### DIFF
--- a/twilio-rb.gemspec
+++ b/twilio-rb.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency                'activesupport', '>= 3.0.0'
   s.add_dependency                'i18n',          '~> 0.5'
-  s.add_dependency                'yajl-ruby',     '>= 0.7.7'
+  s.add_dependency                'yajl-ruby',     '~> 0.8.3'
   s.add_dependency                'httparty',      '>= 0.6.1'
   s.add_dependency                'builder',       '>= 3.0.0'
   s.add_dependency                'jwt',           '>= 0.1.3'


### PR DESCRIPTION
This change to the gemspec stops the yajl-ruby deprecation warning from being emitted (a) in any project that uses twilio-rb, and (b) when running the twilio-rb specs.  See the discussion I had with Brian in the link found in the commit message below.

```
* yajl-ruby 1.0.0 issues a warning that 2.0.0 will deprecate it's JSON API compatibility ( https://github.com/brianmario/yajl-ruby/commit/3127064144ee3944586941f9d637d6257a5d2aca ).  Restrict the yajl-ruby dependency to ~> 0.8.3 until (a) yajl-ruby defines its new "coder" API, and (b) twilio-rb is updated to use this new API.
```
