### PR TITLE
Format may not be set

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,33 @@
 PATH
   remote: .
   specs:
-    twilio-rb (1.0beta3)
+    twilio-rb (2.0.0)
       activesupport (>= 3.0.0)
       builder (>= 2.1.2)
       httparty (>= 0.6.1)
-      i18n (~> 0.5.0)
+      i18n (~> 0.5)
       jwt (>= 0.1.3)
-      yajl-ruby (>= 0.7.7)
+      yajl-ruby (~> 0.8.3)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.0.10)
+    activesupport (3.1.1)
+      multi_json (~> 1.0)
     addressable (2.2.6)
     builder (3.0.0)
     crack (0.1.8)
     diff-lcs (1.1.3)
-    httparty (0.7.8)
-      crack (= 0.1.8)
-    i18n (0.5.0)
-    json (1.5.3)
+    httparty (0.8.1)
+      multi_json
+      multi_xml
+    i18n (0.6.0)
+    json (1.6.1)
     jwt (0.1.3)
       json (>= 1.2.4)
     mocha (0.9.12)
+    multi_json (1.0.3)
+    multi_xml (0.4.1)
     rake (0.8.7)
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
@@ -35,7 +39,7 @@ GEM
     rspec-mocks (2.6.0)
     timecop (0.3.5)
     webmock (1.7.5)
-      addressable (> 2.2.5, ~> 2.2)
+      addressable (~> 2.2, > 2.2.5)
       crack (>= 0.1.7)
     yajl-ruby (0.8.3)
 

--- a/lib/twilio/request_filter.rb
+++ b/lib/twilio/request_filter.rb
@@ -6,7 +6,9 @@ module Twilio
   module RequestFilter
     def filter(controller)
       request = controller.request
-      if request.format.voice? && request.ssl?
+      format  = request.format
+
+      if format && format.voice? && request.ssl?
         controller.head(:forbidden) if expected_signature_for(request) != request.env['X-Twilio-Signature']
       end
     end

--- a/spec/request_filter_spec.rb
+++ b/spec/request_filter_spec.rb
@@ -55,5 +55,14 @@ describe 'Twilio::RequestFilter' do
         Twilio::RequestFilter.filter(controller)
       end
     end
+
+    context "when format is not available" do
+      it 'does not raise' do
+        request = mock :format => nil
+        controller = mock :request => request
+
+        lambda { Twilio::RequestFilter.filter(controller) }.should_not raise_error
+      end
+    end
   end
 end

--- a/twilio-rb.gemspec
+++ b/twilio-rb.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency                'i18n',          '~> 0.5'
   s.add_dependency                'yajl-ruby',     '~> 0.8.3'
   s.add_dependency                'httparty',      '>= 0.6.1'
-  s.add_dependency                'builder',       '>= 3.0.0'
+  s.add_dependency                'builder',       '>= 2.1.2'
   s.add_dependency                'jwt',           '>= 0.1.3'
 
   s.add_development_dependency    'webmock',       '>= 1.6.1'


### PR DESCRIPTION
When an unexpected format is requested format may not be set and a NoMethodError is triggered. 

You can reproduce by doing /path.gif. 
