### PR TITLE
Rails 3.1 Compatability

### DIFF
--- a/lib/twilio/request_filter.rb
+++ b/lib/twilio/request_filter.rb
@@ -6,16 +6,16 @@ module Twilio
   module RequestFilter
     def filter(controller)
       request = controller.request
-      if request.format.voice? && request.ssl?
-        controller.head(:forbidden) if expected_signature_for(request) != request.env['X-Twilio-Signature']
+      if request.format.try(:voice?) && request.ssl?
+        controller.head(:forbidden) if expected_signature_for(request) != request.env['HTTP_X_TWILIO_SIGNATURE']
       end
     end
 
     private
     def expected_signature_for(request)
-      string_to_sign = request.url + request.params.sort.join
-      digest         = OpenSSL::Digest::Digest.new 'sha1'
-      hash           = OpenSSL::HMAC.digest digest, Twilio::AUTH_TOKEN, string_to_sign
+      string_to_sign = request.url + request.request_parameters.sort.join
+      digest         = OpenSSL::Digest::Digest.new('sha1')
+      hash           = OpenSSL::HMAC.digest(digest, Twilio::AUTH_TOKEN, string_to_sign)
 
       Base64.encode64(hash).strip
     end


### PR DESCRIPTION
Hi Steve,

The library was not working in rails 3.1 due to the signature validation failing. The way the request parameters and headers have changed in rails 3.1, so these changes reflect that. I'm not sure if you'd want to merge this into the regular branch or a pre-release branch for rails 3.1.

Let me know if you have any questions.

Cheers,
Dan
