### PR TITLE
Fix: Switched from 'register_alias' to 'register' so that the 'RequestFilter' works as expected

### DIFF
--- a/lib/railtie.rb
+++ b/lib/railtie.rb
@@ -26,7 +26,7 @@ module Twilio
       ActionController::Base.class_eval { before_filter Twilio::RequestFilter }
 
       ::ActionView::Template.register_template_handler(:voice, ActionView::Template::Handlers::TwiML)
-      ::Mime::Type.register_alias 'text/xml', :voice
+      ::Mime::Type.register 'text/xml', :voice
     end
   end
 end


### PR DESCRIPTION
On Rails 3.1.4 the `Twilio::RequestFilter` does not ever check the signature of a request when the mime type is set to `text/xml`.

This is because the mime type is registered as an alias. Changing:

```
::Mime::Type.register_alias 'text/xml', :voice
```

To

```
::Mime::Type.register 'text/xml', :voice
```

Means that

```
request.format.try(:voice?)
```

Will then return true when required. The test cases do not pick this up as the `format.voice?` method is stubbed.

I'm not certain if this is just isolated to Rails 3.1.4 or not, but AFAIK there have been no major changes to the way Mime types are handled in the Rails 3.1-3.2 series.
