### PR TITLE
Allow newer versions of httparty

### DIFF
--- a/twilio-rb.gemspec
+++ b/twilio-rb.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency                'activesupport', '>= 3.0.0'
   s.add_dependency                'i18n',          '~> 0.5'
-  s.add_dependency                'httparty',      '~> 0.10.0'
+  s.add_dependency                'httparty',      '>= 0.10.0'
   s.add_dependency                'crack',         '~> 0.3.2'
   s.add_dependency                'builder',       '>= 3.2.2'
   s.add_dependency                'jwt',           '>= 0.1.3'


### PR DESCRIPTION
httparty 0.11 came out in April, and I found at least [one gem](http://rubygems.org/gems/pushover) which is now incompatible alongside twilio-rb.
