### PR TITLE
Rails 4 compatibility

### DIFF
--- a/lib/twilio-rb.rb
+++ b/lib/twilio-rb.rb
@@ -10,4 +10,4 @@ end
 
 Dir[File.join(File.dirname(__FILE__), 'twilio', '*.rb')].each { |lib| require lib }
 
-require File.join(File.dirname(__FILE__), 'railtie.rb') if Object.const_defined?(:Rails) && Rails.version =~ /^3/
+require File.join(File.dirname(__FILE__), 'railtie.rb') if Object.const_defined?(:Rails) && Rails::VERSION::MAJOR >= 3

--- a/lib/twilio/request_filter.rb
+++ b/lib/twilio/request_filter.rb
@@ -10,6 +10,7 @@ module Twilio
         controller.head(:forbidden) if expected_signature_for(request) != (request.env['HTTP_X_TWILIO_SIGNATURE'] || request.env['X-Twilio-Signature'])
       end
     end
+    alias before filter
 
     private
     def expected_signature_for(request)

--- a/spec/request_filter_spec.rb
+++ b/spec/request_filter_spec.rb
@@ -3,37 +3,12 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe 'Twilio::RequestFilter' do
   before { Twilio::Config.setup :account_sid => 'AC000000000000', :auth_token => '1c892n40nd03kdnc0112slzkl3091j20' }
 
-  describe '.filter' do
-    context 'when request signatures do match' do
-      it 'does not trigger a 401 response' do
-        request = stub \
-          :request_parameters => {
-                'AccountSid' => 'AC9a9f9392lad99kla0sklakjs90j092j3', 'ApiVersion' => '2010-04-01',
-                'CallSid' => 'CAd800bb12c0426a7ea4230e492fef2a4f', 'CallStatus' => 'ringing',
-                'Called' => '+15306384866', 'CalledCity' => 'OAKLAND', 'CalledCountry' => 'US',
-                'CalledState' => 'CA', 'CalledZip' => '94612', 'Caller' => '+15306666666',
-                'CallerCity' => 'SOUTH LAKE TAHOE', 'CallerCountry' => 'US',
-                'CallerName' => 'CA Wireless Call', 'CallerState' => 'CA',
-                'CallerZip' => '89449', 'Direction' => 'inbound', 'From' => '+15306666666',
-                'FromCity' => 'SOUTH LAKE TAHOE', 'FromCountry' => 'US', 'FromState' => 'CA',
-                'FromZip' => '89449', 'To' => '+15306384866', 'ToCity' => 'OAKLAND',
-                'ToCountry' => 'US', 'ToState' => 'CA', 'ToZip' => '94612' },
-          :env    => {
-                'X-Twilio-Signature' => 'fF+xx6dTinOaCdZ0aIeNkHr/ZAA=',
-                'HTTP_X_TWILIO_SIGNATURE' => 'fF+xx6dTinOaCdZ0aIeNkHr/ZAA=' },
-          :format => mock(:voice? => true),
-          :url    => 'http://www.postbin.org/1ed898x'
+  [:filter, :before].each do |method_name|
 
-        controller = stub :request => request
-
-        controller.expects(:head).with(:forbidden).never
-        Twilio::RequestFilter.filter(controller)
-      end
-    end
-
-    context 'when request signatures do not match' do
-      it 'returns 401 response' do
-         request = stub \
+    describe ".#{method_name}" do
+      context 'when request signatures do match' do
+        it 'does not trigger a 401 response' do
+          request = stub \
             :request_parameters => {
                   'AccountSid' => 'AC9a9f9392lad99kla0sklakjs90j092j3', 'ApiVersion' => '2010-04-01',
                   'CallSid' => 'CAd800bb12c0426a7ea4230e492fef2a4f', 'CallStatus' => 'ringing',
@@ -45,16 +20,44 @@ describe 'Twilio::RequestFilter' do
                   'FromCity' => 'SOUTH LAKE TAHOE', 'FromCountry' => 'US', 'FromState' => 'CA',
                   'FromZip' => '89449', 'To' => '+15306384866', 'ToCity' => 'OAKLAND',
                   'ToCountry' => 'US', 'ToState' => 'CA', 'ToZip' => '94612' },
-            :env => {
-                  'X-Twilio-Signature' => nil,
-                  'HTTP_X_TWILIO_SIGNATURE' => nil },
+            :env    => {
+                  'X-Twilio-Signature' => 'fF+xx6dTinOaCdZ0aIeNkHr/ZAA=',
+                  'HTTP_X_TWILIO_SIGNATURE' => 'fF+xx6dTinOaCdZ0aIeNkHr/ZAA=' },
             :format => mock(:voice? => true),
             :url    => 'http://www.postbin.org/1ed898x'
 
-        controller = stub :request => request
+          controller = stub :request => request
 
-        controller.expects(:head).with(:forbidden)
-        Twilio::RequestFilter.filter(controller)
+          controller.expects(:head).with(:forbidden).never
+          Twilio::RequestFilter.send(method_name, controller)
+        end
+      end
+
+      context 'when request signatures do not match' do
+        it 'returns 401 response' do
+           request = stub \
+              :request_parameters => {
+                    'AccountSid' => 'AC9a9f9392lad99kla0sklakjs90j092j3', 'ApiVersion' => '2010-04-01',
+                    'CallSid' => 'CAd800bb12c0426a7ea4230e492fef2a4f', 'CallStatus' => 'ringing',
+                    'Called' => '+15306384866', 'CalledCity' => 'OAKLAND', 'CalledCountry' => 'US',
+                    'CalledState' => 'CA', 'CalledZip' => '94612', 'Caller' => '+15306666666',
+                    'CallerCity' => 'SOUTH LAKE TAHOE', 'CallerCountry' => 'US',
+                    'CallerName' => 'CA Wireless Call', 'CallerState' => 'CA',
+                    'CallerZip' => '89449', 'Direction' => 'inbound', 'From' => '+15306666666',
+                    'FromCity' => 'SOUTH LAKE TAHOE', 'FromCountry' => 'US', 'FromState' => 'CA',
+                    'FromZip' => '89449', 'To' => '+15306384866', 'ToCity' => 'OAKLAND',
+                    'ToCountry' => 'US', 'ToState' => 'CA', 'ToZip' => '94612' },
+              :env => {
+                    'X-Twilio-Signature' => nil,
+                    'HTTP_X_TWILIO_SIGNATURE' => nil },
+              :format => mock(:voice? => true),
+              :url    => 'http://www.postbin.org/1ed898x'
+
+          controller = stub :request => request
+
+          controller.expects(:head).with(:forbidden)
+          Twilio::RequestFilter.send(method_name, controller)
+        end
       end
     end
   end

--- a/twilio-rb.gemspec
+++ b/twilio-rb.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency                'i18n',          '~> 0.5'
   s.add_dependency                'httparty',      '>= 0.10.0'
   s.add_dependency                'crack',         '~> 0.3.2'
-  s.add_dependency                'builder',       '>= 3.2.2'
+  s.add_dependency                'builder',       '>= 3.1.0'
   s.add_dependency                'jwt',           '>= 0.1.3'
 
   s.add_development_dependency    'webmock',       '>= 1.6.1'


### PR DESCRIPTION
I'd like to apologize. Indenting the specs for `Twilio::RequestFilter` to cover both `.filter` and `.before` resulted in a fairly confusing diff. None of the specs were changed, otherwise.

This pull request:
- Lowers the required version of builder to `>= 3.1.0` rather than `>= 3.2.2`, solving a conflict with [actionpack](https://rubygems.org/gems/actionpack) 4.0.0 which specifies a dependency on builder `~> 3.1.0`.
- Silences a Rails 4.0.0 deprecation warning in `Twilio::RequestFilter`. Filter objects can now specify `#before`, `#after`, and `#around` methods when used in a controller. For now, an alias is used (it might be more suitable to switch the alias around, given `.filter` is the method that was deprecated).
- Railtie for `voice` responses is loaded in Rails 3.0.0 and up.

Anyway, let me know what your thoughts are on this. Thanks for maintaining this awesome gem!
