### PR TITLE
Don't double-escape SendDigits; Compatibility with Rails 3.x.x

### DIFF
--- a/lib/twilio/call.rb
+++ b/lib/twilio/call.rb
@@ -14,7 +14,6 @@ module Twilio
       def create(attrs={})
         attrs = attrs.with_indifferent_access
         attrs.each { |k,v| v.upcase! if k.to_s =~ /method$/ }
-        attrs[:send_digits] = CGI.escape(attrs[:send_digits]) if attrs[:send_digits]
         attrs['if_machine'].try :capitalize
         old_create attrs
       end

--- a/spec/call_spec.rb
+++ b/spec/call_spec.rb
@@ -296,14 +296,14 @@ describe Twilio::Call do
 
       before do
         stub_request(:post, resource_uri + '.json').
-          with(:body => "To=%2B14155551212&From=%2B14158675309&Url=http%3A%2F%2Flocalhost%3A3000%2Fhollaback&SendDigits=1234%252300&IfMachine=Continue").
+          with(:body => "To=%2B14155551212&From=%2B14158675309&Url=http%3A%2F%2Flocalhost%3A3000%2Fhollaback&SendDigits=1234%2300&IfMachine=Continue").
           to_return(:status => 200, :body => canned_response('call_created'))
       end
 
       context 'using a twilio connect subaccount' do
         it 'uses the account sid as the username for basic auth' do
           stub_request(:post, resource_uri('AC0000000000000000000000000000', true) + '.json' ).
-            with(:body => "To=%2B14155551212&From=%2B14158675309&Url=http%3A%2F%2Flocalhost%3A3000%2Fhollaback&SendDigits=1234%252300&IfMachine=Continue").
+            with(:body => "To=%2B14155551212&From=%2B14158675309&Url=http%3A%2F%2Flocalhost%3A3000%2Fhollaback&SendDigits=1234%2300&IfMachine=Continue").
             to_return :body => canned_response('connect_call_created'), :status => 200
           Twilio::Call.create :to => '+14155551212', :from => '+14158675309', :url => 'http://localhost:3000/hollaback',
             :send_digits => '1234#00', :if_machine => 'Continue', :account_sid => 'AC0000000000000000000000000000', :connect => true
@@ -344,14 +344,14 @@ describe Twilio::Call do
       it 'escapes send digits because pound, i.e. "#" has special meaning in a url' do
         call
         a_request(:post, resource_uri + '.json').
-          with(:body => "To=%2B14155551212&From=%2B14158675309&Url=http%3A%2F%2Flocalhost%3A3000%2Fhollaback&SendDigits=1234%252300&IfMachine=Continue").
+          with(:body => "To=%2B14155551212&From=%2B14158675309&Url=http%3A%2F%2Flocalhost%3A3000%2Fhollaback&SendDigits=1234%2300&IfMachine=Continue").
           should have_been_made
       end
 
       it 'capitalises the value of "IfMachine" parameter' do
         call
         a_request(:post, resource_uri + '.json').
-          with(:body => "To=%2B14155551212&From=%2B14158675309&Url=http%3A%2F%2Flocalhost%3A3000%2Fhollaback&SendDigits=1234%252300&IfMachine=Continue").
+          with(:body => "To=%2B14155551212&From=%2B14158675309&Url=http%3A%2F%2Flocalhost%3A3000%2Fhollaback&SendDigits=1234%2300&IfMachine=Continue").
           should have_been_made
       end
     end

--- a/twilio-rb.gemspec
+++ b/twilio-rb.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency                'i18n',          '~> 0.5'
   s.add_dependency                'httparty',      '>= 0.10.0'
   s.add_dependency                'crack',         '~> 0.3.2'
-  s.add_dependency                'builder',       '>= 3.1.0'
+  s.add_dependency                'builder',       '>= 3.0.0'
   s.add_dependency                'jwt',           '>= 0.1.3'
 
   s.add_development_dependency    'webmock',       '>= 1.6.1'


### PR DESCRIPTION
When I included a pound sign in send_digits, like so:

``` ruby
Twilio::Call.create(
  to: "...",
  from: "...",
  url: "...",
  send_digits: "34#"
)
```

I started encountering [this Twilio error](https://www.twilio.com/docs/errors/21206), with the following message:

> Invalid sendDigits: 34%23

After much digging, I discovered that the problem was that Twilio::Call.create escapes `:send_digits` with CGI.escape. This is unnecessary because HTTParty already does it. So, this caused `:send_digits` to be escaped twice, making the string invalid.

This pull request contains a fix for that, and also a minor tweak to the gemspec to make the gem compatible with Rails 3.x.x. These versions of rails require builder 3.0.0, so the requirement of builder 3.1 was too high.
